### PR TITLE
Do not try loading other Python libs when one is provided by user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## vNEXT
 ### Highlights :tada:
 + Fix getting types of the facades methods arguments in the `native_impl` method implementation in Scala 3. Create new test class `SpecialCasesTest` ([PR #237](https://github.com/shadaj/scalapy/pull/237))
++ No longer try to load other Python library versions when the one specified by user fails to load ([PR #270](https://github.com/shadaj/scalapy/pull/270))
 
 ### Bug Fixes :bug:
 + Avoid compiler crashes when accessing dynamic fields and methods whose names collide with internal names ([PR #247](https://github.com/shadaj/scalapy/pull/247))


### PR DESCRIPTION
If a certain Python library version is specified by user, Scalapy should not try loading other versions if that one fails to load. Instead, it should just exit and throw an exception immediately instead of trying to load another Python version that is not the one the user wants (see #248).

Also shorten that `try` block by replacing it with `Try`.

This is another issue but currently when there is no user specified Python library, we try to load Python 3.7 then 3.8 then 3.9. Should we try the latest version first? i.e 3.9 then 3.8...?

