### PR TITLE
Try to load latest Python version first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Highlights :tada:
 + Fix getting types of the facades methods arguments in the `native_impl` method implementation in Scala 3. Create new test class `SpecialCasesTest` ([PR #237](https://github.com/shadaj/scalapy/pull/237))
 + No longer try to load other Python library versions when the one specified by user fails to load ([PR #270](https://github.com/shadaj/scalapy/pull/270))
++ Scalapy now tries to load the latest Python version first if no specific version was set by user ([PR #273](https://github.com/shadaj/scalapy/pull/273))
 
 ### Bug Fixes :bug:
 + Avoid compiler crashes when accessing dynamic fields and methods whose names collide with internal names ([PR #247](https://github.com/shadaj/scalapy/pull/247))

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -10,9 +10,9 @@ class CPythonAPIInterface {
       .map(Seq(_))
       .getOrElse(Seq(
         "python3",
-        "python3.7", "python3.7m",
+        "python3.9", "python3.9m",
         "python3.8", "python3.8m",
-        "python3.9", "python3.9m"
+        "python3.7", "python3.7m"
       ))
 
   val loadAttempts = pythonLibrariesToTry.toStream.map(n => Try(Native.register(n)))


### PR DESCRIPTION
follow up from #270

btw I have been using scalapy with python 3.10 (though not intensively) and things work fine. Should we add support for it as well or is there anything that might break?