### PR TITLE
Keep last JNA exception as cause when failing to load libpython

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
     steps:
       - uses: actions/checkout@master
       - name: Set up JDK 1.8 and SBT

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -20,7 +20,8 @@ class CPythonAPIInterface {
 
   loadAttempts.find(_.isSuccess).getOrElse {
     loadAttempts.foreach(_.failed.get.printStackTrace())
-    throw new Exception(s"Unable to locate Python library, tried ${pythonLibrariesToTry.mkString(", ")}")
+    val lastExceptionOpt = loadAttempts.reverseIterator.collectFirst { case Failure(e) => e }
+    throw new Exception(s"Unable to locate Python library, tried ${pythonLibrariesToTry.mkString(", ")}", lastExceptionOpt.orNull)
   }
 
   @scala.native def Py_SetProgramName(str: WString): Unit

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -10,6 +10,7 @@ class CPythonAPIInterface {
       .map(Seq(_))
       .getOrElse(Seq(
         "python3",
+        "python3.10", "python3.10m",
         "python3.9", "python3.9m",
         "python3.8", "python3.8m",
         "python3.7", "python3.7m"


### PR DESCRIPTION
This makes it easier to debug things, when ScalaPy fails to load libpython. In some contexts, the output gets swallowed or is cumbersome to get, so [printing stacktraces](https://github.com/scalapy/scalapy/blob/4dd92464b48abf3a373890944a1ec206f1093cb7/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala#L21) doesn't allow to easily recover the JNA exceptions.