### PR TITLE
Report traceback in PythonException

### DIFF
--- a/core/shared/src/test/scala/me/shadaj/scalapytests/ErrorTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapytests/ErrorTest.scala
@@ -54,4 +54,18 @@ class ErrorTest extends AnyFunSuite {
       assert(exp.getMessage.contains("NameError"))
     }
   }
+
+  test("PythonException contains a traceback") {
+    local {
+      val exp = intercept[PythonException] {
+        exec("raise Exception")
+      }
+      val msgLines = exp.getMessage.linesIterator.toVector
+      val expectedFirstLines = Seq(
+        "Traceback (most recent call last):",
+        """  File "<string>", line 1, in <module>"""
+      )
+      assert(msgLines.startsWith(expectedFirstLines))
+    }
+  }
 }


### PR DESCRIPTION
This adds a "traceback" message in the `PythonException`s thrown by ScalaPy. I find those useful (if not required 😅) to debug errors originating from Python.

Note that this introduces some kind of cycle between `CPythonInterpreter` and the `py` package object (with the former using the latter to load the `traceback` module, while the latter is basically a frontend for the former). To circumvent possible infinite loops (with the `traceback` module failing to load, triggering a Python error, that would attempt to load `traceback` to report its error, which would fail to load `traceback`, etc.), we only let one call use traceback stuff at a time.

This allows to get things like
```text
scala> CPythonInterpreter.execManyLines("raise Exception")
me.shadaj.scalapy.py.PythonException: Traceback (most recent call last):
  File "<string>", line 1, in <module>
<class 'Exception'>
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.$anonfun$throwErrorIfOccured$2(CPythonInterpreter.scala:378)
  at me.shadaj.scalapy.interpreter.Platform$.Zone(Platform.scala:10)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.$anonfun$throwErrorIfOccured$1(CPythonInterpreter.scala:349)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.withGil(CPythonInterpreter.scala:162)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.throwErrorIfOccured(CPythonInterpreter.scala:348)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.$anonfun$execManyLines$2(CPythonInterpreter.scala:188)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.withGil(CPythonInterpreter.scala:162)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.$anonfun$execManyLines$1(CPythonInterpreter.scala:180)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.$anonfun$execManyLines$1$adapted(CPythonInterpreter.scala:179)
  at me.shadaj.scalapy.interpreter.Platform$.Zone(Platform.scala:10)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.execManyLines(CPythonInterpreter.scala:179)
  ... 32 elided
```

rather than just
```text
scala> CPythonInterpreter.execManyLines("raise Exception")
me.shadaj.scalapy.py.PythonException: <class 'Exception'>
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.$anonfun$throwErrorIfOccured$2(CPythonInterpreter.scala:378)
  at me.shadaj.scalapy.interpreter.Platform$.Zone(Platform.scala:10)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.$anonfun$throwErrorIfOccured$1(CPythonInterpreter.scala:349)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.withGil(CPythonInterpreter.scala:162)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.throwErrorIfOccured(CPythonInterpreter.scala:348)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.$anonfun$execManyLines$2(CPythonInterpreter.scala:188)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.withGil(CPythonInterpreter.scala:162)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.$anonfun$execManyLines$1(CPythonInterpreter.scala:180)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.$anonfun$execManyLines$1$adapted(CPythonInterpreter.scala:179)
  at me.shadaj.scalapy.interpreter.Platform$.Zone(Platform.scala:10)
  at me.shadaj.scalapy.interpreter.CPythonInterpreter$.execManyLines(CPythonInterpreter.scala:179)
  ... 32 elided
```

(with the traceback usually containing more useful info for actual exceptions)