### PR TITLE
Add py.exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## vNEXT
+### Highlights :tada:
++ Add `py.exec` method, allowing to execute a piece of Python code ([PR #299](https://github.com/scalapy/scalapy/pull/299))
 
 ## v0.5.2
 ### Highlights :tada:

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/package.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/package.scala
@@ -53,6 +53,10 @@ package object py extends PyMacros {
     Any.populateWith(CPythonInterpreter.load(str)).as[Dynamic]
   }
 
+  def exec(str: String): Unit = {
+    CPythonInterpreter.execManyLines(str)
+  }
+
   final class PyQuotable(val variable: String) extends AnyVal {
     def cleanup() = CPythonInterpreter.cleanupVariableReference(variable)
   }


### PR DESCRIPTION
This adds a `py.exec` method (simply deferring to `CPythonInterpreter.execManyLines` under-the-hood, that is backed by the same CPython API call as the `exec` builtin in Python I think). It's quite convenient to run things such as
```scala
py.exec("foo=2")
py.exec("raise Exception")
```
that `py.eval` (or the `py` string interpolator) doesn't support.