### PR TITLE
Catch java.lang.Error when loading libpython

### DIFF
--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -16,7 +16,12 @@ class CPythonAPIInterface {
         "python3.7", "python3.7m"
       ))
 
-  val loadAttempts = pythonLibrariesToTry.toStream.map(n => Try(Native.register(n)))
+  val loadAttempts = pythonLibrariesToTry.toStream.map(n => try {
+    Native.register(n)
+    Success(true)
+  } catch {
+    case t: Throwable => Failure(t)
+  })
 
   loadAttempts.find(_.isSuccess).getOrElse {
     loadAttempts.foreach(_.failed.get.printStackTrace())


### PR DESCRIPTION
This reverts the commit in #270 trying to simplify thing. Now I see why you did it this way. `Try` will not capture `java.lang.Error`, only `java.lang.Exception` so this workaround is needed.