### PR TITLE
chore: add a clear error while creating a python facade in Scala 3

### DIFF
--- a/coreMacros/src/main/scala-3/me/shadaj/scalapy/py/Facades.scala
+++ b/coreMacros/src/main/scala-3/me/shadaj/scalapy/py/Facades.scala
@@ -69,8 +69,9 @@ object FacadeImpl {
   def creator[T <: Any](using Type[T], Quotes): Expr[FacadeCreator[T]] = 
     import quotes.reflect.*
     if(TypeRepr.of[T].typeSymbol.flags.is(Flags.Trait))
-      report.error(s"${TypeRepr.of[T].show} should be a class, not a trait!")
-    // new FacadeCreator[T] { def create: T = new T }
+      report.error(s"Facade definitions in Scala 3 must be classes, but ${TypeRepr.of[T].show} was defined as a trait")
+
+  // new FacadeCreator[T] { def create: T = new T }
     val creatorMaker = TypeIdent(Symbol.requiredClass("me.shadaj.scalapy.py.CreatorMaker"))
     val anonfunSym = Symbol.newMethod(Symbol.spliceOwner, "$anonfun", 
       MethodType(List())(_ => List(), _ => TypeTree.of[T].tpe))

--- a/coreMacros/src/main/scala-3/me/shadaj/scalapy/py/Facades.scala
+++ b/coreMacros/src/main/scala-3/me/shadaj/scalapy/py/Facades.scala
@@ -68,6 +68,8 @@ object FacadeImpl {
 
   def creator[T <: Any](using Type[T], Quotes): Expr[FacadeCreator[T]] = 
     import quotes.reflect.*
+    if(TypeRepr.of[T].typeSymbol.flags.is(Flags.Trait))
+      report.error(s"${TypeRepr.of[T].show} should be a class, not a trait!")
     // new FacadeCreator[T] { def create: T = new T }
     val creatorMaker = TypeIdent(Symbol.requiredClass("me.shadaj.scalapy.py.CreatorMaker"))
     val anonfunSym = Symbol.newMethod(Symbol.spliceOwner, "$anonfun", 


### PR DESCRIPTION
This PR should solve issue #310: when someone tries to create a facade using a trait definition, the compiler will throw an error.
