### PR TITLE
Ensure that facade methods with empty parentheses always call the underlying method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 ## vNEXT
 ### Highlights :tada:
++ ScalaPy is now published under the `dev.scalapy` organization
 + Add `py.exec` method, allowing to execute a piece of Python code ([PR #299](https://github.com/scalapy/scalapy/pull/299))
+
+### Bug Fixes :bug:
++ Fix facades with methods taking empty-parens parameters reading an attribute instead of calling a function on Scala 3 ([PR #313](https://github.com/scalapy/scalapy/pull/313))
++ Fix crashes due to `py.local` cleaning up the underlying `PyValue` of static facades ([PR #313](https://github.com/scalapy/scalapy/pull/313))
 
 ## v0.5.2
 ### Highlights :tada:

--- a/core/shared/src/main/scala-2/me/shadaj/scalapy/py/Facades.scala
+++ b/core/shared/src/main/scala-2/me/shadaj/scalapy/py/Facades.scala
@@ -8,10 +8,12 @@ class FacadeValueProvider(private[scalapy] val __scalapy__rawValue: PyValue) ext
 
 class StaticModule(name: String) extends Module {
   private[scalapy] val __scalapy__rawValue = module(name).__scalapy_value
+  __scalapy__rawValue.noCleanup = true
 }
 
 class StaticValue(value: Any) extends Any {
   private[scalapy] val __scalapy__rawValue = value.__scalapy_value
+  __scalapy__rawValue.noCleanup = true
 }
 
 abstract class FacadeCreator[F <: Any] {

--- a/core/shared/src/main/scala-3/me/shadaj/scalapy/py/Facades.scala
+++ b/core/shared/src/main/scala-3/me/shadaj/scalapy/py/Facades.scala
@@ -6,10 +6,12 @@ import me.shadaj.scalapy.interpreter.PyValue
 
 trait StaticModule(name: String) extends Module {
   __scalapy__rawValue = module(name).__scalapy_value
+  __scalapy__rawValue.noCleanup = true
 }
 
 trait StaticValue(value: Any) extends Any {
   __scalapy__rawValue = value.__scalapy_value
+  __scalapy__rawValue.noCleanup = true
 }
 
 abstract class FacadeCreator[F <: Any] {

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/package.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/package.scala
@@ -34,7 +34,7 @@ package object py extends PyMacros {
     try {
       f
     } finally {
-      myQueue.foreach(_.finalize())
+      myQueue.foreach(_.cleanup(ignoreCleaned = true))
       assert(PyValue.allocatedValues.get().pop.eq(myQueue))
     }
   }

--- a/core/shared/src/test/scala-2/me/shadaj/scalapytests/TestFacades.scala
+++ b/core/shared/src/test/scala-2/me/shadaj/scalapytests/TestFacades.scala
@@ -9,6 +9,9 @@ import me.shadaj.scalapy.interpreter
 
 @native trait StringModuleFacade extends Module {
   def digits: String = native
+
+  // this is an attribute, not a method
+  def ascii_letters(): String = native
 }
 
 @native object StringModuleStaticFacade extends StaticModule("string") with StringModuleFacade

--- a/core/shared/src/test/scala-3/me/shadaj/scalapytests/TestFacades.scala
+++ b/core/shared/src/test/scala-3/me/shadaj/scalapytests/TestFacades.scala
@@ -12,6 +12,9 @@ import me.shadaj.scalapy.interpreter
 
 @native class StringModuleFacade extends Module {
   def digits: String = native
+
+  // this is an attribute, not a method
+  def ascii_letters(): String = native
 }
 
 @native object StringModuleStaticFacade extends StringModuleFacade with StaticModule("string")

--- a/core/shared/src/test/scala/me/shadaj/scalapytests/ModuleTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapytests/ModuleTest.scala
@@ -23,6 +23,14 @@ class ModuleTest extends AnyFunSuite {
     }
   }
 
+  test("Calling an empty parens facade function does not read attributes") {
+    local {
+      assertThrows[PythonException] {
+        StringModuleStaticFacade.ascii_letters()
+      }
+    }
+  }
+
   test("Can import module attributes through subname") {
     local {
       assert(module("string", "digits").as[String] == "0123456789")

--- a/core/shared/src/test/scala/me/shadaj/scalapytests/SpecialSyntaxTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapytests/SpecialSyntaxTest.scala
@@ -50,7 +50,7 @@ class SpecialSyntaxTest extends AnyFunSuite {
       val myClass = types.new_class("MyClass")
       
       val weakref = module("weakref")
-      val value =  myClass()
+      val value = myClass()
       var cleaned = false
       val reference = weakref.ref(value, (_: Any) => {
         cleaned = true

--- a/coreMacros/src/main/scala-3/me/shadaj/scalapy/py/Facades.scala
+++ b/coreMacros/src/main/scala-3/me/shadaj/scalapy/py/Facades.scala
@@ -100,8 +100,9 @@ object FacadeImpl {
     val methodName = methodSymbol.name
     val refss = methodSymbolParameterRefs(methodSymbol)
 
-    if refss.length > 1 then
-      report.throwError(s"method $methodName has curried parameter lists.")
+    if (refss.length > 1) {
+      report.throwError(s"Method $methodName has curried parameter lists, which are currently not supported in facades")
+    }
 
     val args = refss.headOption.toList.flatten
 
@@ -109,34 +110,30 @@ object FacadeImpl {
     if (Symbol.spliceOwner.owner.hasAnnotation(Symbol.requiredClass("me.shadaj.scalapy.py.PyBracketAccess"))) {
       if (args.size == 0) {
         report.throwError("PyBracketAccess functions require at least one parameter")
-      }
-      else if (args.size == 1) {
+      } else if (args.size == 1) {
         val bracketAccessAST = Apply(TypeApply(Select.unique(Apply(Select.unique(Apply(TypeApply(
           Select.unique(resolveThis,"as"),List(TypeIdent(Helper.classDynamicSymbol))),List(evidenceForDynamic)),  
           "bracketAccess"),List(constructASTforMethodFrom(args(0)))),"as"), List(TypeTree.of[T])),List(evidenceForTypeT))
 
         bracketAccessAST.asExprOf[T]
-      }
-      else if (args.size == 2) {
+      } else if (args.size == 2) {
         val bracketUpdateAST = Apply(Select.unique(Apply(TypeApply(
           Select.unique(resolveThis,"as"),List(TypeIdent(Helper.classDynamicSymbol))),List(evidenceForDynamic)),  
           "bracketUpdate"),List(constructASTforMethodFrom(args(0)), constructASTforMethodFrom(args(1))))
 
           bracketUpdateAST.asExprOf[T]
-      }
-      else {
+      } else {
         report.throwError("Too many parameters to PyBracketAccess function")
       }
     }
     else {
-      if (args.isEmpty) {
+      if (refss.isEmpty) {
         val selectDynamicAST = Apply(TypeApply(Select.unique(Apply(Select.unique(Apply(TypeApply(
           Select.unique(resolveThis,"as"),List(TypeIdent(Helper.classDynamicSymbol))),List(evidenceForDynamic)),  
           "selectDynamic"),List(Expr(methodName).asTerm)),"as"), List(TypeTree.of[T])),List(evidenceForTypeT))
 
         selectDynamicAST.asExprOf[T]
-      }
-      else {
+      } else {
         val typedVarargs = Typed(Inlined(None, Nil, Repeated(args.map(arg => constructASTforMethodFrom(arg)),
           TypeIdent(Helper.classAnySymbol))),Applied(TypeIdent(defn.RepeatedParamClass),List(TypeIdent(Helper.classAnySymbol))))
 
@@ -164,8 +161,9 @@ object FacadeImpl {
     val methodName = methodSymbol.name
     val refss = methodSymbolParameterRefs(methodSymbol)
 
-    if refss.length > 1 then
-      report.throwError(s"method $methodName has curried parameter lists.")
+    if (refss.length > 1) {
+      report.throwError(s"Method $methodName has curried parameter lists, which are currently not supported in facades")
+    }
 
     val args = refss.headOption.toList.flatten
     
@@ -175,8 +173,7 @@ object FacadeImpl {
         "selectDynamic"),List(Expr(methodName).asTerm)),"as"),List(TypeTree.of[T])),List(evidenceForTypeT))
 
       selectDynamicAST.asExprOf[T]
-    }
-    else {
+    } else {
       def constructASTforMethodFrom(arg: quotes.reflect.Term) = {
         val applyArgTypeToWriter = Helper.writerTypeRepr.appliedTo(arg.tpe.widen)
         val tree = Apply(Apply(TypeApply(Ref(Helper.methodFromSymbol),List(Inferred(arg.tpe.widen))),List(arg)),

--- a/docs/interacting-with-python.md
+++ b/docs/interacting-with-python.md
@@ -167,3 +167,5 @@ py.local {
 ```
 
 In this code, we can manipulate the values allocated inside the `py.local` block as long as we are still in its scope. If we try to access the values after the block ends, we will get an exception.
+
+**Note:** using `py.local` requires careful reasoning about where different Python values will be initialized, since ScalaPy only uses the stack to compute which values should be cleaned. For example, if an object is lazily initialized inside a `py.local` block, any Python values stored there will be cleaned because they will be seen as part of the local block.


### PR DESCRIPTION
Also improves the user experience of using `py.local` with static facades.

Fixes #311