### PR TITLE
Added explicit mention about docs directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ ScalaPy allows you to use any Python library from your Scala code with an intuit
 
 # Get Started at [scalapy.dev](https://scalapy.dev)
 
+**Note: The most up-to-date documentation is always available in github [docs](https://github.com/scalapy/scalapy/tree/main/docs) directory. The website might be a bit outdated sometimes.**
+
 ## Building
 To run the unit tests for ScalaPy, run `sbt coreJVM/test`. To run unit tests for Scala Native, run `sbt coreNative/test`.
 


### PR DESCRIPTION
Since the website is not fully up-to-date, newcomes like me are a bit confused with lack of details. However, I just found out that there are much detailed instructions available under `docs` directory. It is better to mention about that in the README for newbies to explore.