### PR TITLE
Add support for python 3.11 and 3.12

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11", "3.12" ]
     steps:
       - uses: actions/checkout@master
       - name: Set up JDK 1.8 and SBT

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -10,6 +10,8 @@ class CPythonAPIInterface {
       .map(Seq(_))
       .getOrElse(Seq(
         "python3",
+        "python3.12", "python3.12m",
+        "python3.11", "python3.11m",
         "python3.10", "python3.10m",
         "python3.9", "python3.9m",
         "python3.8", "python3.8m",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,7 +104,7 @@ To convert Python values back into Scala, we use the `.as` method and pass in th
 val listLength = listLengthPython.as[Int]
 ```
 ## Execution
-ScalaPy officially supports Python 3.{7, 8, 9}. If you want to use another version of Python, you should either define the environment variable `SCALAPY_PYTHON_LIBRARY`
+ScalaPy officially supports Python 3.{7, 8, 9, 10, 11, 12}. If you want to use another version of Python, you should either define the environment variable `SCALAPY_PYTHON_LIBRARY`
 
 ```shell
 python --version


### PR DESCRIPTION
I've simply added python 3.11 and 3.12 as libraries to look for and all tests have passed, so it seems like the interpreters API didn't change and scalapy was always fine with those versions.

Documentation for python 3.10 was also missing, I've fixed that.