### PR TITLE
Migrate scala3 macros to core

### DIFF
--- a/core/shared/src/main/scala-3/me/shadaj/scalapy/py/FacadesMacros.scala
+++ b/core/shared/src/main/scala-3/me/shadaj/scalapy/py/FacadesMacros.scala
@@ -3,13 +3,13 @@ package me.shadaj.scalapy.py
 import scala.annotation.StaticAnnotation
 
 trait FacadesCreatorMacros {
-  inline implicit def getCreator[F <: Any]: FacadeCreator[F] = ${FacadeImpl.creator[F]}
+  inline implicit def getCreator[F <: Any]: FacadeCreator[F] = ${macros.FacadeImpl.creator[F]}
 }
 
 trait PyMacros {
   class PyBracketAccess extends StaticAnnotation
   class native extends StaticAnnotation
 
-  inline def native[T]: T = ${FacadeImpl.native_impl[T]}
-  inline def nativeNamed[T]: T = ${FacadeImpl.native_named_impl[T]}
+  inline def native[T]: T = ${macros.FacadeImpl.native_impl[T]}
+  inline def nativeNamed[T]: T = ${macros.FacadeImpl.native_named_impl[T]}
 }


### PR DESCRIPTION
This MR migrates `FacadeImpl` from macrosJVM to coreJVM. That resolves the cyclic dependencies and removes the need for the dummy classes `Any` and `FacadeCreator[T]`.

This will resolve #383. 

-----

I've also tried a different solution, removing the dummy classes from the package via sbt configuration. I think the given solution is cleaner and should be preferred. See https://github.com/scalapy/scalapy/commit/9651929cc5a2f0228318e1c920243a540b0f9456

