### PR TITLE
Handle overflows for Byte and Int Readers

### DIFF
--- a/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Reader.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Reader.scala
@@ -39,22 +39,32 @@ object Reader extends TupleReaders with FunctionReaders {
   }
 
   implicit val byteReader: Reader[Byte] = new Reader[Byte] {
+    private val min: Long = Byte.MinValue.toLong
+    private val max: Long = Byte.MaxValue.toLong
     override def readNative(r: Platform.Pointer): Byte = {
       val res = CPythonAPI.PyLong_AsLongLong(r)
       if (res == -1) {
         CPythonInterpreter.throwErrorIfOccured()
       }
 
+      if(res > max || res < min)
+        throw new IllegalArgumentException("Cannot convert value outside of range to Byte")
+
       res.toByte
     }
   }
 
   implicit val intReader: Reader[Int] = new Reader[Int] {
+    private val min: Long = Int.MinValue.toLong
+    private val max: Long = Int.MaxValue.toLong
     override def readNative(r: Platform.Pointer): Int = {
       val res = CPythonAPI.PyLong_AsLongLong(r)
       if (res == -1) {
         CPythonInterpreter.throwErrorIfOccured()
       }
+
+      if(res > max || res < min)
+        throw new IllegalArgumentException("Cannot convert value outside of range to Int")
 
       res.toInt
     }

--- a/core/shared/src/test/scala/me/shadaj/scalapytests/ReaderTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapytests/ReaderTest.scala
@@ -20,9 +20,23 @@ class ReaderTest extends AnyFunSuite {
     }
   }
 
+  test("Reading a byte bigger than Byte.MaxValue throws an Exception") {
+    local{
+      assertThrows[Exception](py"(${Byte.MaxValue.toLong + 1})".as[Byte])
+      assertThrows[Exception](py"(${Byte.MinValue.toLong - 1})".as[Byte])
+    }
+  }
+
   test("Reading an integer") {
     local {
       assert(py"123".as[Int] == 123)
+    }
+  }
+
+  test("Reading an integer bigger than Int.MaxValue throws an Exception") {
+    local{
+      assertThrows[Exception](py"(${Int.MaxValue.toLong + 1})".as[Int])
+      assertThrows[Exception](py"(${Int.MinValue.toLong - 1})".as[Int])
     }
   }
 


### PR DESCRIPTION
Int and Byte Readers crop values with `.toInt` and `.toByte` without checking if they are losing information first.

See test cases for examples.