### PR TITLE
Optimize Seq and Map Readers with Iterator API

### DIFF
--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -75,8 +75,6 @@ class CPythonAPIInterface {
   @scala.native def PyDict_Keys(dict: Platform.Pointer): Platform.Pointer
 
   @scala.native def PyList_New(size: Int): Platform.Pointer
-  @scala.native def PyList_Size(list: Platform.Pointer): NativeLong
-  @scala.native def PyList_GetItem(list: Platform.Pointer, index: NativeLong): Platform.Pointer
   @scala.native def PyList_SetItem(list: Platform.Pointer, index: NativeLong, item: Platform.Pointer): Int
 
   @scala.native def PyTuple_New(size: Int): Platform.Pointer
@@ -93,11 +91,13 @@ class CPythonAPIInterface {
   @scala.native def PyObject_SetAttr(obj: Platform.Pointer, name: Platform.Pointer, newValue: Platform.Pointer): Platform.Pointer
   @scala.native def PyObject_SetAttrString(obj: Platform.Pointer, name: String, newValue: Platform.Pointer): Platform.Pointer
   @scala.native def PyObject_Call(obj: Platform.Pointer, args: Platform.Pointer, kwArgs: Platform.Pointer): Platform.Pointer
-  @scala.native def PyObject_Length(obj: Platform.Pointer): NativeLong
+  @scala.native def PyObject_GetIter(obj: Platform.Pointer): Platform.Pointer
 
   @scala.native def PySequence_GetItem(obj: Platform.Pointer, idx: Int): Platform.Pointer
   @scala.native def PySequence_SetItem(obj: Platform.Pointer, idx: Int, v: Platform.Pointer): Platform.Pointer
   @scala.native def PySequence_Length(obj: Platform.Pointer): NativeLong
+
+  @scala.native def PyIter_Next(obj: Platform.Pointer): Platform.Pointer
 
   @scala.native def PyErr_Occurred(): Platform.Pointer
   @scala.native def PyErr_Fetch(pType: Platform.PointerToPointer, pValue: Platform.PointerToPointer, pTraceback: Platform.PointerToPointer): Unit

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -65,6 +65,7 @@ class CPythonAPIInterface {
   @scala.native def PyFloat_AsDouble(float: Platform.Pointer): Double
 
   @scala.native def PyDict_New(): Platform.Pointer
+  @scala.native def PyDict_Items(dict: Platform.Pointer): Platform.Pointer
   @scala.native def PyDict_SetItem(dict: Platform.Pointer, key: Platform.Pointer, value: Platform.Pointer): Int
   @scala.native def PyDict_SetItemString(dict: Platform.Pointer, key: String, value: Platform.Pointer): Int
   @scala.native def PyDict_Contains(dict: Platform.Pointer, key: Platform.Pointer): Int

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -48,8 +48,6 @@ object CPythonAPI {
   def PyDict_Keys(dict: Platform.Pointer): Platform.Pointer = extern
 
   def PyList_New(size: Int): Platform.Pointer = extern
-  def PyList_Size(list: Platform.Pointer): CSize = extern
-  def PyList_GetItem(list: Platform.Pointer, index: CSize): Platform.Pointer = extern
   def PyList_SetItem(list: Platform.Pointer, index: CSize, item: Platform.Pointer): Int = extern
 
   def PyTuple_New(size: Int): Platform.Pointer = extern
@@ -67,11 +65,13 @@ object CPythonAPI {
   def PyObject_SetAttrString(obj: Platform.Pointer, name: CString, newValue: Platform.Pointer): Platform.Pointer = extern
   def PyObject_CallMethodObjArgs(obj: Platform.Pointer, name: Platform.Pointer, args: CVarArg*): Platform.Pointer = extern
   def PyObject_Call(obj: Platform.Pointer, args: Platform.Pointer, kwArgs: Platform.Pointer): Platform.Pointer = extern
-  def PyObject_Length(obj: Platform.Pointer): CSize = extern
+  def PyObject_GetIter(obj: Platform.Pointer): Platform.Pointer = extern
 
   def PySequence_GetItem(obj: Platform.Pointer, idx: Int): Platform.Pointer = extern
   def PySequence_SetItem(obj: Platform.Pointer, idx: Int, v: Platform.Pointer): Platform.Pointer = extern
   def PySequence_Length(obj: Platform.Pointer): CSize = extern
+
+  def PyIter_Next(obj: Platform.Pointer): Platform.Pointer = extern
 
   def PyErr_Occurred(): Platform.Pointer = extern
   def PyErr_Fetch(pType: Platform.PointerToPointer, pValue: Platform.PointerToPointer, pTraceback: Platform.PointerToPointer): Unit = extern

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -38,6 +38,7 @@ object CPythonAPI {
   def PyFloat_AsDouble(float: Platform.Pointer): Double = extern
 
   def PyDict_New(): Platform.Pointer = extern
+  def PyDict_Items(dict: Platform.Pointer): Platform.Pointer = extern
   def PyDict_SetItem(dict: Platform.Pointer, key: Platform.Pointer, value: Platform.Pointer): Int = extern
   def PyDict_SetItemString(dict: Platform.Pointer, key: CString, value: Platform.Pointer): Int = extern
   def PyDict_Contains(dict: Platform.Pointer, key: Platform.Pointer): Int = extern

--- a/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Reader.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Reader.scala
@@ -137,15 +137,14 @@ object Reader extends TupleReaders with FunctionReaders {
 
   implicit def seqReader[T, C[A] <: Iterable[A]](implicit reader: Reader[T], bf: Factory[T, C[T]]): Reader[C[T]] = new Reader[C[T]] {
     override def readNative(r: Platform.Pointer) = {
+      val builder = bf.newBuilder
+
       val iterator = CPythonAPI.PyObject_GetIter(r)
       CPythonInterpreter.throwErrorIfOccured()
 
-      val builder = bf.newBuilder
-
-      var item = CPythonAPI.PyIter_Next(iterator)
-      CPythonInterpreter.throwErrorIfOccured()
-
       try {
+        var item = CPythonAPI.PyIter_Next(iterator)
+        CPythonInterpreter.throwErrorIfOccured()
         while (item != null) {
           try {
             builder += reader.readNative(item)

--- a/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Reader.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Reader.scala
@@ -147,7 +147,11 @@ object Reader extends TupleReaders with FunctionReaders {
 
       try {
         while (item != null) {
-          builder += reader.readNative(item)
+          try {
+            builder += reader.readNative(item)
+          } finally {
+            CPythonAPI.Py_DecRef(item)
+          }
           item = CPythonAPI.PyIter_Next(iterator)
           CPythonInterpreter.throwErrorIfOccured()
         }
@@ -177,7 +181,11 @@ object Reader extends TupleReaders with FunctionReaders {
           CPythonInterpreter.throwErrorIfOccured()
 
           while (item != null) {
-            builder += readerT.readNative(item)
+            try {
+              builder += readerT.readNative(item)
+            } finally {
+              CPythonAPI.Py_DecRef(item)
+            }
             item = CPythonAPI.PyIter_Next(iterator)
             CPythonInterpreter.throwErrorIfOccured()
           }

--- a/core/shared/src/test/scala/me/shadaj/scalapytests/ReaderTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapytests/ReaderTest.scala
@@ -110,6 +110,14 @@ class ReaderTest extends AnyFunSuite {
     }
   }
 
+  test("Reading from a set works") {
+    local {
+      val arr = py"{1, 2, 3}"
+      assert(arr.as[Seq[Int]] == Seq(1, 2, 3))
+      assert(arr.as[Set[Int]] == Set(1, 2, 3))
+    }
+  }
+
   test("Reading as a mutable sequence lets us observe mutations and edit the sequence") {
     local {
       val list = py"[1, 2, 3]"


### PR DESCRIPTION
I've taken a look into issue #315 and noticed that random access with `PySequence_GetItem` was used to read individual items. Lists are generally slow with random access and the iterator protocol gives better performance when reading all items. So I've switched over to the iterator protocol for `Reader[Seq[_]]` and `Reader[Map[_, _]]`. A simple benchmark shows a speedup of 20-30%.

As more data structures support the iterator protocol than the random access protocol, it also allows the `Reader[Seq[_]]` to read more data structures, like sets. So this PR resolves issue #315.

<details>
<summary>Benchmark code</summary>

```
package me.shadaj.scalapy.py

import me.shadaj.scalapy.py
import org.scalatest.funsuite.AnyFunSuite

class ReadBenchmarkTest extends AnyFunSuite{
  test("benchmark seq"){
    val t0 = System.currentTimeMillis()
    val d = 0 until 10_000
    val ints = py.eval(d.mkString("[", ",", "]"))
    for(_ <- 0 until 1_000){
      ints.as[Seq[Int]]
    }
    val t1 = System.currentTimeMillis()
    info(s"${t1 - t0} ms")

    // new: 3418 ms
    // old: 4201 ms
  }

  test("benchmark map"){
    val t0 = System.currentTimeMillis()
    val d = (0 until 10_000).map(i => s"$i: $i")
    val map = py.eval(d.mkString("{", ",", "}"))
    for(_ <- 0 until 1_000){
      map.as[Map[Int, Int]]
    }
    val t1 = System.currentTimeMillis()
    info(s"${t1 - t0} ms")
    // new: 27923 ms
    // old: 38645 ms
  }
}
```
</details>
