### PR TITLE
Add Writer and Reader for Array[Byte]

### DIFF
--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -101,6 +101,7 @@ class CPythonAPIInterface {
   @scala.native def PyIter_Next(obj: Platform.Pointer): Platform.Pointer
 
   @scala.native def PyBytes_FromStringAndSize(string: Array[Byte], len: NativeLong): Platform.Pointer
+  @scala.native def PyBytes_AsStringAndSize(obj: Platform.Pointer, string: Platform.Pointer, len: Platform.Pointer): Int
 
   @scala.native def PyErr_Occurred(): Platform.Pointer
   @scala.native def PyErr_Fetch(pType: Platform.PointerToPointer, pValue: Platform.PointerToPointer, pTraceback: Platform.PointerToPointer): Unit

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -100,6 +100,8 @@ class CPythonAPIInterface {
 
   @scala.native def PyIter_Next(obj: Platform.Pointer): Platform.Pointer
 
+  @scala.native def PyBytes_FromStringAndSize(string: Array[Byte], len: NativeLong): Platform.Pointer
+
   @scala.native def PyErr_Occurred(): Platform.Pointer
   @scala.native def PyErr_Fetch(pType: Platform.PointerToPointer, pValue: Platform.PointerToPointer, pTraceback: Platform.PointerToPointer): Unit
   @scala.native def PyErr_Print(): Unit

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
@@ -25,9 +25,9 @@ object Platform {
 
   def threadLocalWithInitial[T](initial: () => T) = java.lang.ThreadLocal.withInitial(() => initial())
 
-  def allocPointerToPointer: PointerToPointer = {
-    new jna.Memory(Native.POINTER_SIZE)
-  }
+  def allocPointer[To]: Pointer = new jna.Memory(Native.POINTER_SIZE)
+
+  def allocPointerToPointer: PointerToPointer = allocPointer
 
   def pointerToLong(pointer: Pointer): Long = {
     jna.Pointer.nativeValue(pointer)
@@ -38,6 +38,13 @@ object Platform {
 
   def intToCLong(int: Int): jna.NativeLong = new jna.NativeLong(int)
   def intToCSize(int: Int): jna.NativeLong = new jna.NativeLong(int)
+
+  def dereferenceAsLong(pointer: Pointer): Long = pointer.getLong(0)
+
+  // this `from` pointer is a **char
+  def copyBytes(from: Pointer, size: Int): Array[Byte] = {
+    from.getPointer(0).getByteArray(0, size)
+  }
 
   def dereferencePointerToPointer(pointer: PointerToPointer): Pointer = pointer.getPointer(0)
 

--- a/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
+++ b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
@@ -81,4 +81,6 @@ object Platform {
   def setPtrByte(ptr: Pointer, offset: Int, value: Byte): Unit = ptr.setByte(offset, value)
 
   def toCWideString[T](str: String)(fn: jna.WString => T): T = fn(new jna.WString(str))
+
+  def getArrayStartPointer[A](array: Array[A]): Array[A] = array
 }

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -74,6 +74,8 @@ object CPythonAPI {
 
   def PyIter_Next(obj: Platform.Pointer): Platform.Pointer = extern
 
+  def PyBytes_FromStringAndSize(string: CString, len: CSize): Platform.Pointer = extern
+
   def PyErr_Occurred(): Platform.Pointer = extern
   def PyErr_Fetch(pType: Platform.PointerToPointer, pValue: Platform.PointerToPointer, pTraceback: Platform.PointerToPointer): Unit = extern
   def PyErr_Print(): Unit = extern

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala
@@ -75,6 +75,7 @@ object CPythonAPI {
   def PyIter_Next(obj: Platform.Pointer): Platform.Pointer = extern
 
   def PyBytes_FromStringAndSize(string: CString, len: CSize): Platform.Pointer = extern
+  def PyBytes_AsStringAndSize(obj: Platform.Pointer, string: Ptr[CString], len: Ptr[Long]): CInt = extern
 
   def PyErr_Occurred(): Platform.Pointer = extern
   def PyErr_Fetch(pType: Platform.PointerToPointer, pValue: Platform.PointerToPointer, pTraceback: Platform.PointerToPointer): Unit = extern

--- a/core/native/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
+++ b/core/native/src/main/scala/me/shadaj/scalapy/interpreter/Platform.scala
@@ -63,4 +63,9 @@ object Platform extends PlatformMacros {
     CPythonAPI.PyMem_RawFree(cwstr.asInstanceOf[Ptr[Byte]])
     t
   }
+
+  def getArrayStartPointer[A](array: Array[A]): Ptr[A] = {
+    import scala.scalanative.unsafe.UnsafeRichArray
+    array.at(0)
+  }
 }

--- a/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Writer.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/readwrite/Writer.scala
@@ -8,7 +8,7 @@ import me.shadaj.scalapy.py
 import me.shadaj.scalapy.py.|
 import me.shadaj.scalapy.py.PyQuote
 import me.shadaj.scalapy.interpreter.CPythonAPI
-import CPythonInterpreter.withGil
+import CPythonInterpreter.{throwErrorIfOccured, withGil}
 
 abstract class Writer[T] {
   // no guarantees about references
@@ -83,6 +83,14 @@ object Writer extends TupleWriters with FunctionWriters {
       }
 
       obj
+    }
+  }
+
+  implicit val bytesWriter: Writer[Array[Byte]] = new Writer[Array[Byte]] {
+    override def writeNative(v: Array[Byte]): Platform.Pointer = {
+      val buffer = CPythonAPI.PyBytes_FromStringAndSize(Platform.getArrayStartPointer(v), Platform.intToCSize(v.length))
+      throwErrorIfOccured()
+      buffer
     }
   }
 }

--- a/core/shared/src/test/scala/me/shadaj/scalapytests/ReaderTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapytests/ReaderTest.scala
@@ -153,4 +153,13 @@ class ReaderTest extends AnyFunSuite {
       assert(py"(1, 2)".as[(Int, Int)] == (1, 2))
     }
   }
+
+  test("Reading bytes") {
+    local {
+      assert(py"b'123'".as[Array[Byte]].toList == List('1', '2', '3').map(_.toByte))
+
+      val data = Array.tabulate(256)(_.toByte)
+      assert(Any.from(data).as[Array[Byte]].toList == data.toList)
+    }
+  }
 }

--- a/core/shared/src/test/scala/me/shadaj/scalapytests/WriterTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapytests/WriterTest.scala
@@ -144,4 +144,25 @@ class WriterTest extends AnyFunSuite {
       assert(Dynamic.global.tuple(tuple).toString == "(1, 2)")
     }
   }
+
+  test("Writing a byte array"){
+    local{
+      val data: Array[Byte] = (0 to 255).map(_.toByte).toArray
+      val written = Any.from(data)
+      assert(py"type($written)".toString == "<class 'bytes'>")
+
+      info(s"written: $written")
+
+      for(i <- 0 to 255)
+        assert(written.as[Dynamic].bracketAccess(i).toString == i.toString)
+
+      val expected = data.map{
+        byte =>
+          val padded = ("0" + java.lang.Byte.toUnsignedInt(byte).toHexString).takeRight(2)
+          s"\\x${padded}"
+      }.mkString("b'", "", "'")
+
+      assert(py"$written == ${eval(expected)}".toString == "True")
+    }
+  }
 }

--- a/core/shared/src/test/scala/me/shadaj/scalapytests/WriterTest.scala
+++ b/core/shared/src/test/scala/me/shadaj/scalapytests/WriterTest.scala
@@ -151,8 +151,6 @@ class WriterTest extends AnyFunSuite {
       val written = Any.from(data)
       assert(py"type($written)".toString == "<class 'bytes'>")
 
-      info(s"written: $written")
-
       for(i <- 0 to 255)
         assert(written.as[Dynamic].bracketAccess(i).toString == i.toString)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.1.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.5")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.17")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.2")
 


### PR DESCRIPTION
Issue #320 has a good idea to improve performance when writing and reading binary data.

This PR implements those 2 transformations with pythons `bytes` data type. 

The performance difference is notable:
```
[info] TempBenchmarkTest:
[info] - write Seq[Byte] (old)
[info]   + 2550 ms
[info] - write Array[Byte] (new)
[info]   + 37 ms
[info] - read Seq[Byte] (old)
[info]   + 4017 ms
[info] - read Array[Byte] (new)
[info]   + 2 ms
```

<details>
<summary>Benchmark code</summary>

```
package me.shadaj.scalapy.py

import me.shadaj.scalapy.py
import org.scalatest.funsuite.AnyFunSuite
import me.shadaj.scalapy.readwrite.Writer._

class TempBenchmarkTest extends AnyFunSuite{
  test("write Seq[Byte] (old)"){
    val data = Seq.tabulate(10000000)(_.toByte)

    val t0 = System.currentTimeMillis()
    data.toPythonCopy
    val t1 = System.currentTimeMillis()
    info(s"${t1 - t0} ms")
  }

  test("write Array[Byte] (new)"){
    val data = Array.tabulate(10000000)(_.toByte)

    val t0 = System.currentTimeMillis()
    py.Any.from(data)
    val t1 = System.currentTimeMillis()
    info(s"${t1 - t0} ms")
  }

  test("read Seq[Byte] (old)"){
    val data = Seq.tabulate(10000000)(_.toByte).toPythonCopy

    val t0 = System.currentTimeMillis()
    data.as[Seq[Byte]]
    val t1 = System.currentTimeMillis()
    info(s"${t1 - t0} ms")
  }

  test("read Array[Byte] (new)"){
    val data = py.Any.from(Array.tabulate(10000000)(_.toByte))

    val t0 = System.currentTimeMillis()
    data.as[Array[Byte]]
    val t1 = System.currentTimeMillis()
    info(s"${t1 - t0} ms")
  }
}
```
</details>

Resolves #320 
