### PR TITLE
Fix warnings for None being allocated globally

### DIFF
--- a/core/shared/src/main/scala-2/me/shadaj/scalapy/py/None.scala
+++ b/core/shared/src/main/scala-2/me/shadaj/scalapy/py/None.scala
@@ -1,8 +1,0 @@
-package me.shadaj.scalapy
-
-import me.shadaj.scalapy.interpreter.CPythonInterpreter
-import me.shadaj.scalapy.py.Any
-
-object PyNone {
-  @py.native trait None extends Any
-}

--- a/core/shared/src/main/scala-2/me/shadaj/scalapy/py/PyNone.scala
+++ b/core/shared/src/main/scala-2/me/shadaj/scalapy/py/PyNone.scala
@@ -1,0 +1,9 @@
+package me.shadaj.scalapy.py
+
+import me.shadaj.scalapy.interpreter.{CPythonInterpreter, PyValue}
+
+object PyNone {
+  object None extends Any {
+    override val __scalapy__rawValue: PyValue = CPythonInterpreter.noneValue
+  }
+}

--- a/core/shared/src/main/scala-3/me/shadaj/scalapy/py/None.scala
+++ b/core/shared/src/main/scala-3/me/shadaj/scalapy/py/None.scala
@@ -1,8 +1,0 @@
-package me.shadaj.scalapy
-
-import me.shadaj.scalapy.interpreter.CPythonInterpreter
-import me.shadaj.scalapy.py.Any
-
-object PyNone {
-  @py.native class None extends Any
-}

--- a/core/shared/src/main/scala-3/me/shadaj/scalapy/py/PyNone.scala
+++ b/core/shared/src/main/scala-3/me/shadaj/scalapy/py/PyNone.scala
@@ -1,0 +1,9 @@
+package me.shadaj.scalapy.py
+
+import me.shadaj.scalapy.interpreter.{CPythonInterpreter, PyValue}
+
+object PyNone {
+  object None extends Any {
+    __scalapy__rawValue = CPythonInterpreter.noneValue
+  }
+}

--- a/core/shared/src/main/scala/me/shadaj/scalapy/py/package.scala
+++ b/core/shared/src/main/scala/me/shadaj/scalapy/py/package.scala
@@ -14,9 +14,9 @@ package object py extends PyMacros {
   def module(name: String) = Module(name)
   def module(name: String, subname: String) = Module(name, subname)
 
-  val None = Any.populateWith(CPythonInterpreter.noneValue).as[PyNone.None]
+  val None = PyNone.None
 
-  type NoneOr[T] = PyNone.None | T
+  type NoneOr[T] = PyNone.None.type | T
 
   def `with`[T <: py.Any, O](ref: T)(withValue: T => O): O = {
     ref.as[Dynamic](Reader.facadeReader[Dynamic](FacadeCreator.getCreator[Dynamic])).__enter__()


### PR DESCRIPTION
Resolve #351

@shadaj's response in #356 is correct. The `py.None` value was constructed with `safeGlobal = true`, so it didn't trigger the warning. 
The problem lies with the `.as[PyNone.None]`. It uses the default facade creator macro to construct new instances which were not declared to be `safeGlobal`, so the warning got printed. Those instances are also not really necessary, so they waste memory.